### PR TITLE
Add basic STL box designer skeleton

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from stl_box_designer import launch
+
+if __name__ == '__main__':
+    launch()

--- a/stl_box_designer/__init__.py
+++ b/stl_box_designer/__init__.py
@@ -1,0 +1,14 @@
+from .main_window import MainWindow, launch
+from .box_model import BoxModel
+from .compartment import CompartmentSystem
+from .cutout import CutoutPattern
+from .splitter import AutoSplitter
+
+__all__ = [
+    'MainWindow',
+    'launch',
+    'BoxModel',
+    'CompartmentSystem',
+    'CutoutPattern',
+    'AutoSplitter',
+]

--- a/stl_box_designer/box_model.py
+++ b/stl_box_designer/box_model.py
@@ -1,0 +1,15 @@
+class BoxModel:
+    """Data model for a rectangular box."""
+
+    def __init__(self, length=100, width=100, height=50):
+        self.length = length
+        self.width = width
+        self.height = height
+
+    def set_dimensions(self, length, width, height):
+        self.length = length
+        self.width = width
+        self.height = height
+
+    def get_dimensions(self):
+        return self.length, self.width, self.height

--- a/stl_box_designer/compartment.py
+++ b/stl_box_designer/compartment.py
@@ -1,0 +1,15 @@
+class CompartmentSystem:
+    """Manages compartments inside a box model."""
+
+    def __init__(self, box_model):
+        self.box_model = box_model
+        self.compartments = []  # list of (x, y, z, w, h, d)
+
+    def add_compartment(self, x, y, z, width, depth, height):
+        self.compartments.append((x, y, z, width, depth, height))
+
+    def clear(self):
+        self.compartments = []
+
+    def list_compartments(self):
+        return list(self.compartments)

--- a/stl_box_designer/cutout.py
+++ b/stl_box_designer/cutout.py
@@ -1,0 +1,18 @@
+class CutoutPattern:
+    """Represents a honeycomb cutout pattern."""
+
+    def __init__(self, box_model, density=0.5):
+        self.box_model = box_model
+        self.density = density  # 0..1
+        self.enabled = False
+
+    def enable(self, density=None):
+        self.enabled = True
+        if density is not None:
+            self.density = density
+
+    def disable(self):
+        self.enabled = False
+
+    def is_enabled(self):
+        return self.enabled

--- a/stl_box_designer/main_window.py
+++ b/stl_box_designer/main_window.py
@@ -1,0 +1,59 @@
+from PyQt5 import QtWidgets
+from .box_model import BoxModel
+from .compartment import CompartmentSystem
+from .cutout import CutoutPattern
+from .splitter import AutoSplitter
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window with basic box editor."""
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("STL Box Designer")
+        self.box_model = BoxModel()
+        self.compartment_system = CompartmentSystem(self.box_model)
+        self.cutout_pattern = CutoutPattern(self.box_model)
+        self.splitter = AutoSplitter(self.box_model)
+        self._build_ui()
+
+    def _build_ui(self):
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QFormLayout(central)
+
+        self.x_input = QtWidgets.QSpinBox()
+        self.x_input.setRange(1, 1000)
+        self.x_input.setValue(100)
+        self.y_input = QtWidgets.QSpinBox()
+        self.y_input.setRange(1, 1000)
+        self.y_input.setValue(100)
+        self.z_input = QtWidgets.QSpinBox()
+        self.z_input.setRange(1, 1000)
+        self.z_input.setValue(50)
+
+        layout.addRow("Length (X)", self.x_input)
+        layout.addRow("Width (Y)", self.y_input)
+        layout.addRow("Height (Z)", self.z_input)
+
+        apply_btn = QtWidgets.QPushButton("Apply")
+        apply_btn.clicked.connect(self.apply_dimensions)
+        layout.addRow(apply_btn)
+
+        self.setCentralWidget(central)
+
+    def apply_dimensions(self):
+        """Apply dimension changes to the box model."""
+        x = self.x_input.value()
+        y = self.y_input.value()
+        z = self.z_input.value()
+        self.box_model.set_dimensions(x, y, z)
+        # further UI updates or previews would go here
+
+
+def launch():
+    app = QtWidgets.QApplication([])
+    win = MainWindow()
+    win.show()
+    app.exec_()
+
+if __name__ == "__main__":
+    launch()

--- a/stl_box_designer/splitter.py
+++ b/stl_box_designer/splitter.py
@@ -1,0 +1,25 @@
+class AutoSplitter:
+    """Splits box models that exceed max dimensions."""
+
+    def __init__(self, box_model, max_dim=256):
+        self.box_model = box_model
+        self.max_dim = max_dim
+        self.parts = []
+
+    def split(self):
+        length, width, height = self.box_model.get_dimensions()
+        self.parts = []
+        if any(dim > self.max_dim for dim in (length, width, height)):
+            # placeholder: simple half split along longest dimension
+            if length >= width and length >= height:
+                self.parts.append({'length': length/2, 'width': width, 'height': height})
+                self.parts.append({'length': length/2, 'width': width, 'height': height})
+            elif width >= length and width >= height:
+                self.parts.append({'length': length, 'width': width/2, 'height': height})
+                self.parts.append({'length': length, 'width': width/2, 'height': height})
+            else:
+                self.parts.append({'length': length, 'width': width, 'height': height/2})
+                self.parts.append({'length': length, 'width': width, 'height': height/2})
+        else:
+            self.parts.append({'length': length, 'width': width, 'height': height})
+        return self.parts

--- a/tests/test_box_model.py
+++ b/tests/test_box_model.py
@@ -1,0 +1,12 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from stl_box_designer import BoxModel
+
+class TestBoxModel(unittest.TestCase):
+    def test_dimensions(self):
+        box = BoxModel()
+        box.set_dimensions(10, 20, 30)
+        self.assertEqual(box.get_dimensions(), (10, 20, 30))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_compartment.py
+++ b/tests/test_compartment.py
@@ -1,0 +1,13 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from stl_box_designer import BoxModel, CompartmentSystem
+
+class TestCompartmentSystem(unittest.TestCase):
+    def test_add_compartment(self):
+        box = BoxModel()
+        cs = CompartmentSystem(box)
+        cs.add_compartment(0, 0, 0, 10, 10, 10)
+        self.assertEqual(len(cs.list_compartments()), 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cutout.py
+++ b/tests/test_cutout.py
@@ -1,0 +1,16 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from stl_box_designer import BoxModel, CutoutPattern
+
+class TestCutoutPattern(unittest.TestCase):
+    def test_enable_disable(self):
+        box = BoxModel()
+        cp = CutoutPattern(box)
+        self.assertFalse(cp.is_enabled())
+        cp.enable()
+        self.assertTrue(cp.is_enabled())
+        cp.disable()
+        self.assertFalse(cp.is_enabled())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,19 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from stl_box_designer import BoxModel, AutoSplitter
+
+class TestAutoSplitter(unittest.TestCase):
+    def test_split_needed(self):
+        box = BoxModel(300, 100, 100)
+        sp = AutoSplitter(box, max_dim=256)
+        parts = sp.split()
+        self.assertEqual(len(parts), 2)
+
+    def test_no_split(self):
+        box = BoxModel(200, 200, 200)
+        sp = AutoSplitter(box, max_dim=256)
+        parts = sp.split()
+        self.assertEqual(len(parts), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create stl_box_designer package with GUI skeleton
- implement BoxModel, CompartmentSystem, CutoutPattern and AutoSplitter
- provide a simple PyQt MainWindow for editing dimensions
- add small unit tests for each component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f937dedc4832abb741825b7a5f834